### PR TITLE
fix referral id error

### DIFF
--- a/rust/src/api/btc_ln.rs
+++ b/rust/src/api/btc_ln.rs
@@ -372,7 +372,7 @@ impl BtcLnV2Swap {
             boltz_url,
             script_address,
             out_amount,
-            referral_id,
+            referral_id: Some(referral_id.unwrap_or_default()),
         }
     }
 

--- a/rust/src/api/lbtc_ln.rs
+++ b/rust/src/api/lbtc_ln.rs
@@ -383,7 +383,7 @@ impl LbtcLnV2Swap {
             out_amount,
             blinding_key,
             script_address: out_address,
-            referral_id,
+            referral_id: Some(referral_id.unwrap_or_default()),
         }
     }
     pub fn new_submarine(


### PR DESCRIPTION
This error stems from no argument getting passed to the response.