### PR TITLE
Build: Add config.toml for explicit ios sdk resolution + clean up dar…

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,0 +1,17 @@
+[target.aarch64-apple-ios]
+rustflags = [
+  "-C", "link-arg=-isysroot", "-C", "link-arg=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk",
+  "-C", "link-arg=-L/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib"
+]
+
+[target.x86_64-apple-ios]
+rustflags = [
+  "-C", "link-arg=-isysroot", "-C", "link-arg=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk",
+  "-C", "link-arg=-L/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/lib"
+]
+
+[target.aarch64-apple-ios-sim]
+rustflags = [
+  "-C", "link-arg=-isysroot", "-C", "link-arg=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk",
+  "-C", "link-arg=-L/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/lib"
+]

--- a/rust/darwin.sh
+++ b/rust/darwin.sh
@@ -5,20 +5,14 @@ ROOT="target"
 VERSION=$1
 NAME="libboltz"
 BUILD_DIR=$ROOT/$NAME.$VERSION
-# MACOS_DIR="../macos" # final binaries stored here
-# IOS_DIR="../ios" # final binaries stored here
 FRAMEWORK="libboltz.xcframework"
 LIBNAME=libboltzclient.a
 
 IOS_LIPO_DIR=$BUILD_DIR/ios-sim-lipo
-# MAC_LIPO_DIR=$BUILD_DIR/mac-lipo
 IOS_LIPO=$IOS_LIPO_DIR/$LIBNAME
-# MAC_LIPO=$MAC_LIPO_DIR/$LIBNAME
 
 if [ -d "$IOS_LIPO_DIR" ]; then rm -r $IOS_LIPO_DIR
 fi
-# if [ -d "$MAC_LIPO_DIR" ]; then rm -r $MAC_LIPO_DIR
-# fi
 if [ -d "$BUILD_DIR/$FRAMEWORK" ]; then rm -r $BUILD_DIR/$FRAMEWORK
 fi
 
@@ -29,37 +23,28 @@ for TARGET in \
     aarch64-apple-ios \
     x86_64-apple-ios \
     aarch64-apple-ios-sim
-#     aarch64-apple-ios \
-#     x86_64-apple-ios \
-#     aarch64-apple-ios-sim \
-#     x86_64-apple-darwin \
-#     aarch64-apple-darwin
 do
+    echo "Building for $TARGET..."
     rustup target add $TARGET
-    cargo build --release --target=$TARGET
+    cargo build --release --target=$TARGET || { echo "Build failed for $TARGET"; exit 1; }
 done
 
+echo "Creating universal binary for simulators..."
 cargo install cargo-lipo
-cargo lipo --release
+cargo lipo --release --targets x86_64-apple-ios,aarch64-apple-ios-sim || { echo "Lipo failed for simulators"; exit 1; }
+
+mkdir -p $IOS_LIPO_DIR
+cp target/universal/release/$LIBNAME $IOS_LIPO
 
 # Create XCFramework zip
 lipo -create -output $IOS_LIPO \
-        target/aarch64-apple-ios-sim/release/$LIBNAME \
-        target/x86_64-apple-ios/release/$LIBNAME
+    target/aarch64-apple-ios-sim/release/$LIBNAME \
+    target/x86_64-apple-ios/release/$LIBNAME
 
-# lipo -create -output $MAC_LIPO \
-#         target/aarch64-apple-darwin/release/$LIBNAME \
-#         target/x86_64-apple-darwin/release/$LIBNAME
-
+echo "Creating XCFramework..."
 xcodebuild -create-xcframework \
-        -library $IOS_LIPO \
-        -library target/aarch64-apple-ios/release/$LIBNAME \
-        -output $BUILD_DIR/$FRAMEWORK
-# xcodebuild -create-xcframework \
-#         -library $IOS_LIPO \
-#         -library $MAC_LIPO \
-#         -library target/aarch64-apple-ios/release/$LIBNAME \
-#         -output $BUILD_DIR/$FRAMEWORK
+    -library $IOS_LIPO \
+    -library target/aarch64-apple-ios/release/$LIBNAME \
+    -output $BUILD_DIR/$FRAMEWORK || { echo "XCFramework creation failed"; exit 1; }
 
-# rm -rf $IOS_LIPO_DIR $MAC_LIPO_DIR
 rm -rf $IOS_LIPO_DIR 


### PR DESCRIPTION
…win.sh

### DESCRIPTION
I was getting build errors on a new Macbook. Was caused by an error where cargo was linking a dependency needed by secp256k1-zkp as MacOS instead of iOS. Explicit directions to use the Xcode versions of iOS SDKs in config.toml seem to fix it. Without this, the current binary in the 0.1.5 release is broken. 

This doesn't affect Android builds.