### PR TITLE
fix: version compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.2
-  flutter_rust_bridge: 2.0.0
+  flutter_rust_bridge: ^2.0.0
   ffi: ^2.0.1
   meta: ^1.8.0
   uuid: ^4.1.0


### PR DESCRIPTION
This PR make this project compatible with other packages that depend on `flutter_rust_bridge` version `^2.X.X`

```sh
Because every version of bip85 depends on flutter_rust_bridge ^2.6.0 and every version of boltz_dart
  from git depends on flutter_rust_bridge 2.0.0, bip85 is incompatible with boltz_dart from git.
So, because bb_mobile depends on both boltz_dart from git and bip85 any, version solving failed.
 ```