### PR TITLE
Fix: pass referral id to chain swaps

### DIFF
--- a/rust/src/api/chain_swap.rs
+++ b/rust/src/api/chain_swap.rs
@@ -186,7 +186,7 @@ impl ChainSwap {
                     preimage_hash: preimage.sha256,
                     claim_public_key: Some(claim_public_key),
                     refund_public_key: Some(refund_public_key),
-                    referral_id: None,
+                    referral_id: referral_id.clone(),
                     user_lock_amount: Some(amount),
                     server_lock_amount: None,
                     pair_hash: None,
@@ -248,7 +248,7 @@ impl ChainSwap {
                     preimage_hash: preimage.sha256,
                     claim_public_key: Some(claim_public_key),
                     refund_public_key: Some(refund_public_key),
-                    referral_id: None,
+                    referral_id: referral_id.clone(),
                     user_lock_amount: Some(amount),
                     server_lock_amount: None,
                     pair_hash: None, // Add address signature here.


### PR DESCRIPTION
Chain swaps referral_id was hardcoded to None instead of passing Option from params