### PR TITLE
Add reproducible binary verification workflow

### DIFF
--- a/cargokit/build_tool/lib/src/build_tool.dart
+++ b/cargokit/build_tool/lib/src/build_tool.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
-import 'package:ed25519_edwards/ed25519_edwards.dart';
+import 'package:ed25519_edwards/ed25519_edwards.dart' as ed25519;
 import 'package:github/github.dart';
 import 'package:hex/hex.dart';
 import 'package:logging/logging.dart';
@@ -13,6 +13,7 @@ import 'build_pod.dart';
 import 'logging.dart';
 import 'options.dart';
 import 'precompile_binaries.dart';
+import 'reproduce_binaries.dart';
 import 'target.dart';
 import 'util.dart';
 import 'verify_binaries.dart';
@@ -86,7 +87,7 @@ class GenKeyCommand extends Command {
 
   @override
   void run() {
-    final kp = generateKey();
+    final kp = ed25519.generateKey();
     final private = HEX.encode(kp.privateKey.bytes);
     final public = HEX.encode(kp.publicKey.bytes);
     print("Private Key: $private");
@@ -186,7 +187,7 @@ class PrecompileBinariesCommand extends Command {
       return res;
     }).toList(growable: false);
     final precompileBinaries = PrecompileBinaries(
-      privateKey: PrivateKey(privateKey),
+      privateKey: ed25519.PrivateKey(privateKey),
       githubToken: githubToken,
       manifestDir: manifestDir,
       repositorySlug: RepositorySlug.full(argResults!['repository'] as String),
@@ -198,6 +199,130 @@ class PrecompileBinariesCommand extends Command {
     );
 
     await precompileBinaries.run();
+  }
+}
+
+class ReproduceBinariesCommand extends Command {
+  ReproduceBinariesCommand() {
+    argParser
+      ..addOption(
+        'manifest-dir',
+        mandatory: true,
+        help: 'Directory containing Cargo.toml',
+      )
+      ..addMultiOption(
+        'target',
+        help: 'Rust target triple of artifact to reproduce. '
+            'Can be specified multiple times. If omitted, all targets '
+            'buildable on the current host are checked. Android targets are '
+            'also checked when --android-sdk-location is set.',
+      )
+      ..addOption(
+        'android-sdk-location',
+        help: 'Location of Android SDK (if available)',
+      )
+      ..addOption(
+        'android-ndk-version',
+        help: 'Android NDK version (if available)',
+      )
+      ..addOption(
+        'android-min-sdk-version',
+        help: 'Android minimum required version (if available)',
+      )
+      ..addOption(
+        'url-prefix',
+        help: 'Override cargokit.yaml precompiled_binaries.url_prefix.',
+      )
+      ..addOption(
+        'public-key',
+        help: 'Override cargokit.yaml precompiled_binaries.public_key.',
+      )
+      ..addOption(
+        'temp-dir',
+        help: 'Directory to store temporary build artifacts',
+      )
+      ..addFlag(
+        'keep-temp',
+        defaultsTo: false,
+        help: 'Keep temporary build artifacts when --temp-dir is omitted.',
+      )
+      ..addFlag(
+        'verbose',
+        abbr: 'v',
+        defaultsTo: false,
+        help: 'Enable verbose logging',
+      );
+  }
+
+  @override
+  final name = 'reproduce-binaries';
+
+  @override
+  final description = 'Rebuild published binaries locally and compare them '
+      'byte-for-byte against signed GitHub release assets.';
+
+  @override
+  Future<void> run() async {
+    final verbose = argResults!['verbose'] as bool;
+    if (verbose) {
+      enableVerboseLogging();
+    }
+
+    final manifestDir = argResults!['manifest-dir'] as String;
+    if (!Directory(manifestDir).existsSync()) {
+      throw ArgumentError('Manifest directory does not exist: $manifestDir');
+    }
+
+    String? androidMinSdkVersionString =
+        argResults!['android-min-sdk-version'] as String?;
+    int? androidMinSdkVersion;
+    if (androidMinSdkVersionString != null) {
+      androidMinSdkVersion = int.tryParse(androidMinSdkVersionString);
+      if (androidMinSdkVersion == null) {
+        throw ArgumentError(
+            'Invalid android-min-sdk-version: $androidMinSdkVersionString');
+      }
+    }
+
+    final targetStrings = argResults!['target'] as List<String>;
+    final targets = targetStrings.map((target) {
+      final res = Target.forRustTriple(target);
+      if (res == null) {
+        throw ArgumentError('Invalid target: $target');
+      }
+      return res;
+    }).toList(growable: false);
+
+    final urlPrefix = argResults!['url-prefix'] as String?;
+    final publicKeyString = argResults!['public-key'] as String?;
+    PrecompiledBinaries? precompiledBinariesOverride;
+    if (urlPrefix != null || publicKeyString != null) {
+      if (urlPrefix == null || publicKeyString == null) {
+        throw ArgumentError(
+            '--url-prefix and --public-key must be passed together');
+      }
+      final publicKey = HEX.decode(publicKeyString);
+      if (publicKey.length != 32) {
+        throw ArgumentError('Public key must be 32 bytes long');
+      }
+      precompiledBinariesOverride = PrecompiledBinaries(
+        uriPrefix: urlPrefix,
+        publicKey: ed25519.PublicKey(publicKey),
+      );
+    }
+
+    final reproduceBinaries = ReproduceBinaries(
+      manifestDir: manifestDir,
+      targets: targets,
+      androidSdkLocation: argResults!['android-sdk-location'] as String?,
+      androidNdkVersion: argResults!['android-ndk-version'] as String?,
+      androidMinSdkVersion: androidMinSdkVersion,
+      precompiledBinariesOverride: precompiledBinariesOverride,
+      tempDir: argResults!['temp-dir'] as String?,
+      keepTemp: argResults!['keep-temp'] as bool,
+    );
+
+    await reproduceBinaries.run();
   }
 }
 
@@ -243,6 +368,7 @@ Future<void> runMain(List<String> args) async {
       ..addCommand(BuildCMakeCommand())
       ..addCommand(GenKeyCommand())
       ..addCommand(PrecompileBinariesCommand())
+      ..addCommand(ReproduceBinariesCommand())
       ..addCommand(VerifyBinariesCommand());
 
     await runner.run(args);

--- a/cargokit/build_tool/lib/src/build_tool.dart
+++ b/cargokit/build_tool/lib/src/build_tool.dart
@@ -142,8 +142,8 @@ class PrecompileBinariesCommand extends Command {
   @override
   final description = 'Prebuild and upload binaries\n'
       'Private key must be passed through PRIVATE_KEY environment variable. '
-      'Use gen_key through generate priave key.\n'
-      'Github token must be passed as GITHUB_TOKEN environment variable.\n';
+      'Use gen-key to generate a private key.\n'
+      'GitHub token must be passed as GITHUB_TOKEN environment variable.\n';
 
   @override
   Future<void> run() async {

--- a/cargokit/build_tool/lib/src/reproduce_binaries.dart
+++ b/cargokit/build_tool/lib/src/reproduce_binaries.dart
@@ -1,0 +1,221 @@
+import 'dart:io';
+
+import 'package:collection/collection.dart';
+import 'package:convert/convert.dart';
+import 'package:crypto/crypto.dart';
+import 'package:ed25519_edwards/ed25519_edwards.dart';
+import 'package:http/http.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+
+import 'artifacts_provider.dart';
+import 'builder.dart';
+import 'cargo.dart';
+import 'crate_hash.dart';
+import 'options.dart';
+import 'precompile_binaries.dart';
+import 'rustup.dart';
+import 'target.dart';
+
+final _log = Logger('reproduce_binaries');
+
+class ReproduceBinaries {
+  ReproduceBinaries({
+    required this.manifestDir,
+    required this.targets,
+    this.androidSdkLocation,
+    this.androidNdkVersion,
+    this.androidMinSdkVersion,
+    this.precompiledBinariesOverride,
+    this.tempDir,
+    this.keepTemp = false,
+  });
+
+  final String manifestDir;
+  final List<Target> targets;
+  final String? androidSdkLocation;
+  final String? androidNdkVersion;
+  final int? androidMinSdkVersion;
+  final PrecompiledBinaries? precompiledBinariesOverride;
+  final String? tempDir;
+  final bool keepTemp;
+
+  Future<void> run() async {
+    final crateInfo = CrateInfo.load(manifestDir);
+    final crateOptions = CargokitCrateOptions.load(manifestDir: manifestDir);
+    final precompiledBinaries =
+        precompiledBinariesOverride ?? crateOptions.precompiledBinaries;
+    if (precompiledBinaries == null) {
+      throw BuildException(
+        'No precompiled_binaries config found in cargokit.yaml. '
+        'Set it there or pass --url-prefix and --public-key.',
+      );
+    }
+
+    final targets = List.of(this.targets);
+    if (targets.isEmpty) {
+      targets.addAll([
+        ...Target.buildableTargets(),
+        if (androidSdkLocation != null) ...Target.androidTargets(),
+      ]);
+    }
+    if (targets.isEmpty) {
+      throw BuildException('No reproducible build targets selected.');
+    }
+
+    final hash = CrateHash.compute(manifestDir);
+    stdout.writeln('Crate hash: $hash');
+    stdout.writeln('Targets: ${targets.map((e) => e.rust).join(', ')}');
+
+    final workDir = tempDir != null
+        ? Directory(tempDir!)
+        : Directory.systemTemp.createTempSync('cargokit_reproduce_');
+    workDir.createSync(recursive: true);
+
+    final deleteTemp = tempDir == null && !keepTemp;
+    final failures = <String>[];
+    try {
+      final buildEnvironment = BuildEnvironment(
+        configuration: BuildConfiguration.release,
+        crateOptions: crateOptions,
+        targetTempDir: workDir.path,
+        manifestDir: manifestDir,
+        crateInfo: crateInfo,
+        isAndroid: androidSdkLocation != null,
+        androidSdkPath: androidSdkLocation,
+        androidNdkVersion: androidNdkVersion,
+        androidMinSdkVersion: androidMinSdkVersion,
+      );
+
+      final rustup = Rustup();
+      for (final target in targets) {
+        stdout.writeln('Building ${target.rust}...');
+        final builder = RustBuilder(
+          target: target,
+          environment: buildEnvironment,
+        );
+        builder.prepare(rustup);
+        final artifactDir = await builder.build();
+
+        final artifacts = getArtifactNames(
+          target: target,
+          libraryName: crateInfo.packageName,
+          remote: true,
+        );
+
+        for (final artifact in artifacts) {
+          final failure = await _reproduceArtifact(
+            artifactDir: artifactDir,
+            artifactName: artifact,
+            target: target,
+            crateHash: hash,
+            precompiledBinaries: precompiledBinaries,
+          );
+          if (failure != null) {
+            failures.add(failure);
+          }
+        }
+      }
+    } finally {
+      if (deleteTemp) {
+        _log.fine('Deleting ${workDir.path}');
+        workDir.deleteSync(recursive: true);
+      } else {
+        stdout.writeln('Build artifacts kept in ${workDir.path}');
+      }
+    }
+
+    if (failures.isNotEmpty) {
+      stderr.writeln('');
+      stderr.writeln('Reproducibility check failed:');
+      for (final failure in failures) {
+        stderr.writeln('- $failure');
+      }
+      throw BuildException('${failures.length} artifact(s) did not reproduce');
+    }
+
+    stdout.writeln('All checked binaries reproduced byte-for-byte.');
+  }
+
+  Future<String?> _reproduceArtifact({
+    required String artifactDir,
+    required String artifactName,
+    required Target target,
+    required String crateHash,
+    required PrecompiledBinaries precompiledBinaries,
+  }) async {
+    final localPath = path.join(artifactDir, artifactName);
+    final localFile = File(localPath);
+    final remoteFileName = PrecompileBinaries.fileName(target, artifactName);
+    final remoteSignatureFileName =
+        PrecompileBinaries.signatureFileName(target, artifactName);
+
+    stdout.write('  $remoteFileName... ');
+    stdout.flush();
+
+    if (!localFile.existsSync()) {
+      stdout.writeln('MISSING LOCAL');
+      return '${target.rust}/$artifactName: missing local artifact at '
+          '$localPath';
+    }
+
+    final prefix = precompiledBinaries.uriPrefix;
+    final remoteUrl = Uri.parse('$prefix$crateHash/$remoteFileName');
+    final signatureUrl =
+        Uri.parse('$prefix$crateHash/$remoteSignatureFileName');
+
+    final signature = await _get(signatureUrl);
+    if (signature.statusCode != 200) {
+      stdout.writeln('MISSING SIGNATURE');
+      return '${target.rust}/$artifactName: signature download failed '
+          '(${signature.statusCode}) $signatureUrl';
+    }
+
+    final remote = await _get(remoteUrl);
+    if (remote.statusCode != 200) {
+      stdout.writeln('MISSING REMOTE');
+      return '${target.rust}/$artifactName: binary download failed '
+          '(${remote.statusCode}) $remoteUrl';
+    }
+
+    if (!verify(
+      precompiledBinaries.publicKey,
+      remote.bodyBytes,
+      signature.bodyBytes,
+    )) {
+      stdout.writeln('INVALID SIGNATURE');
+      return '${target.rust}/$artifactName: signature verification failed';
+    }
+
+    final localBytes = localFile.readAsBytesSync();
+    if (!const ListEquality<int>().equals(localBytes, remote.bodyBytes)) {
+      stdout.writeln('MISMATCH');
+      return '${target.rust}/$artifactName: local '
+          '${localBytes.length} bytes/${_sha256(localBytes)} != remote '
+          '${remote.bodyBytes.length} bytes/${_sha256(remote.bodyBytes)}';
+    }
+
+    stdout.writeln('OK ${localBytes.length} bytes ${_sha256(localBytes)}');
+    return null;
+  }
+
+  static String _sha256(List<int> bytes) {
+    return hex.encode(sha256.convert(bytes).bytes);
+  }
+
+  static Future<Response> _get(Uri url) async {
+    Object? lastError;
+    for (var attempt = 1; attempt <= 3; attempt++) {
+      try {
+        return await get(url);
+      } on SocketException catch (e) {
+        lastError = e;
+        _log.warning(
+          'Download failed ($attempt/3), retrying $url: ${e.message}',
+        );
+        await Future.delayed(Duration(seconds: attempt));
+      }
+    }
+    throw BuildException('Download failed for $url: $lastError');
+  }
+}

--- a/cargokit/docs/precompiled_binaries.md
+++ b/cargokit/docs/precompiled_binaries.md
@@ -93,3 +93,46 @@ By default the `built_tool precompile-binaries` commands build and uploads the b
 
 Android binaries will be built when `--android-sdk-location` and `--android-ndk-version` arguments are provided.
 
+## Reproducing published binaries
+
+`verify-binaries` proves that release assets are present and signed by the
+configured public key. `reproduce-binaries` goes further: it rebuilds the Rust
+crate locally for the selected target, downloads the corresponding signed
+release asset, verifies the signature, and compares the local and remote bytes.
+
+```
+dart run build_tool reproduce-binaries --manifest-dir=../../rust
+```
+
+Use explicit targets to narrow the check:
+
+```
+dart run build_tool reproduce-binaries \
+  --manifest-dir=../../rust \
+  --target aarch64-apple-darwin \
+  --target aarch64-apple-ios
+```
+
+Android targets need the same SDK/NDK arguments as `precompile-binaries`:
+
+```
+dart run build_tool reproduce-binaries \
+  --manifest-dir=../../rust \
+  --android-sdk-location=/usr/local/lib/android/sdk \
+  --android-ndk-version=26.3.11579264 \
+  --android-min-sdk-version=23 \
+  --target aarch64-linux-android
+```
+
+If the crate does not commit a `precompiled_binaries` section in
+`cargokit.yaml`, pass the release URL prefix and public key directly:
+
+```
+dart run build_tool reproduce-binaries \
+  --manifest-dir=../../rust \
+  --url-prefix=https://github.com/<repository-owner>/<repository-name>/releases/download/precompiled_ \
+  --public-key=<public key from gen-key>
+```
+
+For containerized Linux and Android checks, see the scripts in
+`reproducible_builds/`.

--- a/reproducible_builds/Dockerfile.android
+++ b/reproducible_builds/Dockerfile.android
@@ -1,0 +1,45 @@
+ARG DART_IMAGE=dart:3.2.6
+FROM ${DART_IMAGE}
+
+ARG RUST_TOOLCHAIN=stable
+ARG ANDROID_COMMANDLINE_TOOLS=11076708
+ARG ANDROID_NDK_VERSION=26.3.11579264
+ARG ANDROID_PLATFORM=android-35
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    clang \
+    curl \
+    git \
+    libssl-dev \
+    openjdk-17-jdk-headless \
+    pkg-config \
+    unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV CARGO_HOME=/usr/local/cargo
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV PATH=/usr/local/cargo/bin:${PATH}
+
+RUN curl -fsSL https://sh.rustup.rs \
+  | sh -s -- -y --profile minimal --default-toolchain "${RUST_TOOLCHAIN}"
+
+ENV ANDROID_HOME=/opt/android-sdk
+ENV ANDROID_SDK_ROOT=/opt/android-sdk
+ENV PATH=${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools:${PATH}
+
+RUN mkdir -p "${ANDROID_HOME}/cmdline-tools" \
+  && curl -fsSLo /tmp/android-commandline-tools.zip \
+    "https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_COMMANDLINE_TOOLS}_latest.zip" \
+  && unzip -q /tmp/android-commandline-tools.zip -d "${ANDROID_HOME}/cmdline-tools" \
+  && mv "${ANDROID_HOME}/cmdline-tools/cmdline-tools" "${ANDROID_HOME}/cmdline-tools/latest" \
+  && rm /tmp/android-commandline-tools.zip \
+  && yes | sdkmanager --licenses >/dev/null \
+  && sdkmanager \
+    "platform-tools" \
+    "platforms;${ANDROID_PLATFORM}" \
+    "ndk;${ANDROID_NDK_VERSION}"
+
+WORKDIR /work

--- a/reproducible_builds/Dockerfile.linux
+++ b/reproducible_builds/Dockerfile.linux
@@ -1,0 +1,24 @@
+ARG DART_IMAGE=dart:3.2.6
+FROM ${DART_IMAGE}
+
+ARG RUST_TOOLCHAIN=stable
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    clang \
+    curl \
+    git \
+    libssl-dev \
+    pkg-config \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV CARGO_HOME=/usr/local/cargo
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV PATH=/usr/local/cargo/bin:${PATH}
+
+RUN curl -fsSL https://sh.rustup.rs \
+  | sh -s -- -y --profile minimal --default-toolchain "${RUST_TOOLCHAIN}"
+
+WORKDIR /work

--- a/reproducible_builds/README.md
+++ b/reproducible_builds/README.md
@@ -31,6 +31,12 @@ Run Apple target checks directly on a macOS host:
 ./reproducible_builds/reproduce-darwin.sh
 ```
 
+Or through make:
+
+```bash
+make -f reproducible_builds/makefile darwin
+```
+
 Pass explicit targets when you only want part of the Apple matrix:
 
 ```bash
@@ -45,6 +51,12 @@ Run the Linux verifier in Docker:
 
 ```bash
 ./reproducible_builds/reproduce-linux-docker.sh
+```
+
+Or through make:
+
+```bash
+make -f reproducible_builds/makefile linux
 ```
 
 By default this checks `x86_64-unknown-linux-gnu` on `linux/amd64`. Override the
@@ -62,6 +74,12 @@ Run the Android verifier in Docker:
 
 ```bash
 ./reproducible_builds/reproduce-android-docker.sh
+```
+
+Or through make:
+
+```bash
+make -f reproducible_builds/makefile android
 ```
 
 This checks all Android targets supported by Cargokit:

--- a/reproducible_builds/README.md
+++ b/reproducible_builds/README.md
@@ -100,3 +100,39 @@ dart run build_tool reproduce-binaries --manifest-dir=../../rust
 
 Use `--url-prefix` and `--public-key` to check a release source that is not
 declared in `rust/cargokit.yaml`.
+
+## Maintainer Release Checklist
+
+1. Generate a signing keypair:
+
+   ```bash
+   cd cargokit/build_tool
+   dart run build_tool gen-key
+   ```
+
+2. Store the private key in GitHub Actions secrets as
+   `CARGOKIT_PRIVATE_KEY`. Do not commit it.
+
+3. Commit the public key and release URL prefix in `rust/cargokit.yaml`:
+
+   ```yaml
+   precompiled_binaries:
+     url_prefix: https://github.com/SatoshiPortal/boltz-dart/releases/download/precompiled_
+     public_key: <32-byte-ed25519-public-key-hex>
+   ```
+
+4. Build and upload release artifacts from CI with Cargokit's existing
+   `precompile-binaries` command. Android CI needs the Android SDK path, NDK
+   version, and minimum SDK arguments. macOS CI builds macOS and iOS targets.
+
+5. From an independent checkout, run the relevant reproducibility checks:
+
+   ```bash
+   make -f reproducible_builds/makefile linux
+   make -f reproducible_builds/makefile android
+   make -f reproducible_builds/makefile darwin
+   ```
+
+The verification run should print the crate hash, each target, every checked
+artifact name, and a SHA-256 digest for byte-identical artifacts. Any missing
+release asset, invalid signature, or byte mismatch exits non-zero.

--- a/reproducible_builds/README.md
+++ b/reproducible_builds/README.md
@@ -1,0 +1,84 @@
+# Reproducible Binary Checks
+
+This directory contains wrappers for verifying that published Cargokit
+precompiled binaries are reproducible from the checked-out Rust sources.
+
+The flow has two separate checks:
+
+1. `verify-binaries` downloads each release asset and verifies its signature.
+2. `reproduce-binaries` rebuilds the same target locally, downloads the signed
+   release asset, verifies the signature, and compares the local and remote
+   bytes.
+
+No private signing key is needed for reproduction. The command uses the public
+key and URL prefix from `rust/cargokit.yaml` when the crate has a
+`precompiled_binaries` section. If the repository has not committed that
+section yet, pass the values with environment variables:
+
+```bash
+export CARGOKIT_PRECOMPILED_URL_PREFIX='https://github.com/SatoshiPortal/bdk-flutter/releases/download/precompiled_'
+export CARGOKIT_PRECOMPILED_PUBLIC_KEY='<32-byte-ed25519-public-key-hex>'
+```
+
+The release tag must be named `precompiled_<crate-hash>`, which is the same
+layout produced by Cargokit's `precompile-binaries` command.
+
+## macOS and iOS
+
+Run Apple target checks directly on a macOS host:
+
+```bash
+./reproducible_builds/reproduce-darwin.sh
+```
+
+Pass explicit targets when you only want part of the Apple matrix:
+
+```bash
+./reproducible_builds/reproduce-darwin.sh \
+  --target aarch64-apple-darwin \
+  --target aarch64-apple-ios
+```
+
+## Linux
+
+Run the Linux verifier in Docker:
+
+```bash
+./reproducible_builds/reproduce-linux-docker.sh
+```
+
+By default this checks `x86_64-unknown-linux-gnu` on `linux/amd64`. Override the
+platform and target for arm64-capable Docker hosts:
+
+```bash
+DOCKER_PLATFORM=linux/arm64 \
+RUST_TARGET=aarch64-unknown-linux-gnu \
+./reproducible_builds/reproduce-linux-docker.sh
+```
+
+## Android
+
+Run the Android verifier in Docker:
+
+```bash
+./reproducible_builds/reproduce-android-docker.sh
+```
+
+This checks all Android targets supported by Cargokit:
+
+- `armv7-linux-androideabi`
+- `aarch64-linux-android`
+- `i686-linux-android`
+- `x86_64-linux-android`
+
+## Direct Build Tool Usage
+
+The wrappers call the build tool directly:
+
+```bash
+cd cargokit/build_tool
+dart run build_tool reproduce-binaries --manifest-dir=../../rust
+```
+
+Use `--url-prefix` and `--public-key` to check a release source that is not
+declared in `rust/cargokit.yaml`.

--- a/reproducible_builds/README.md
+++ b/reproducible_builds/README.md
@@ -110,8 +110,8 @@ declared in `rust/cargokit.yaml`.
    dart run build_tool gen-key
    ```
 
-2. Store the private key in GitHub Actions secrets as
-   `CARGOKIT_PRIVATE_KEY`. Do not commit it.
+2. Store the private key in GitHub Actions secrets and expose it to
+   `precompile-binaries` as `PRIVATE_KEY`. Do not commit it.
 
 3. Commit the public key and release URL prefix in `rust/cargokit.yaml`:
 

--- a/reproducible_builds/makefile
+++ b/reproducible_builds/makefile
@@ -1,0 +1,18 @@
+.DEFAULT_GOAL := help
+
+.PHONY: help darwin linux android
+
+help:
+	@echo "Available reproducible build checks:"
+	@echo "  make -f reproducible_builds/makefile darwin"
+	@echo "  make -f reproducible_builds/makefile linux"
+	@echo "  make -f reproducible_builds/makefile android"
+
+darwin:
+	./reproducible_builds/reproduce-darwin.sh
+
+linux:
+	./reproducible_builds/reproduce-linux-docker.sh
+
+android:
+	./reproducible_builds/reproduce-android-docker.sh

--- a/reproducible_builds/reproduce-android-docker.sh
+++ b/reproducible_builds/reproduce-android-docker.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE_NAME="${IMAGE_NAME:-bdk-flutter-repro-android}"
+DOCKER_PLATFORM="${DOCKER_PLATFORM:-linux/amd64}"
+ANDROID_NDK_VERSION="${ANDROID_NDK_VERSION:-26.3.11579264}"
+ANDROID_MIN_SDK_VERSION="${ANDROID_MIN_SDK_VERSION:-23}"
+
+docker build \
+  --platform "$DOCKER_PLATFORM" \
+  --build-arg ANDROID_NDK_VERSION="$ANDROID_NDK_VERSION" \
+  -f "$ROOT_DIR/reproducible_builds/Dockerfile.android" \
+  -t "$IMAGE_NAME" \
+  "$ROOT_DIR"
+
+docker run --rm \
+  --platform "$DOCKER_PLATFORM" \
+  -e CARGOKIT_PRECOMPILED_URL_PREFIX="${CARGOKIT_PRECOMPILED_URL_PREFIX:-}" \
+  -e CARGOKIT_PRECOMPILED_PUBLIC_KEY="${CARGOKIT_PRECOMPILED_PUBLIC_KEY:-}" \
+  -v "$ROOT_DIR:/work" \
+  -w /work \
+  "$IMAGE_NAME" \
+  ./reproducible_builds/reproduce.sh \
+    --android-sdk-location=/opt/android-sdk \
+    --android-ndk-version="$ANDROID_NDK_VERSION" \
+    --android-min-sdk-version="$ANDROID_MIN_SDK_VERSION" \
+    --target armv7-linux-androideabi \
+    --target aarch64-linux-android \
+    --target i686-linux-android \
+    --target x86_64-linux-android \
+    "$@"

--- a/reproducible_builds/reproduce-darwin.sh
+++ b/reproducible_builds/reproduce-darwin.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "Apple target reproduction must run on macOS." >&2
+  exit 2
+fi
+
+"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/reproduce.sh" "$@"

--- a/reproducible_builds/reproduce-linux-docker.sh
+++ b/reproducible_builds/reproduce-linux-docker.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE_NAME="${IMAGE_NAME:-bdk-flutter-repro-linux}"
+DOCKER_PLATFORM="${DOCKER_PLATFORM:-linux/amd64}"
+RUST_TARGET="${RUST_TARGET:-x86_64-unknown-linux-gnu}"
+
+docker build \
+  --platform "$DOCKER_PLATFORM" \
+  -f "$ROOT_DIR/reproducible_builds/Dockerfile.linux" \
+  -t "$IMAGE_NAME" \
+  "$ROOT_DIR"
+
+docker run --rm \
+  --platform "$DOCKER_PLATFORM" \
+  -e CARGOKIT_PRECOMPILED_URL_PREFIX="${CARGOKIT_PRECOMPILED_URL_PREFIX:-}" \
+  -e CARGOKIT_PRECOMPILED_PUBLIC_KEY="${CARGOKIT_PRECOMPILED_PUBLIC_KEY:-}" \
+  -v "$ROOT_DIR:/work" \
+  -w /work \
+  "$IMAGE_NAME" \
+  ./reproducible_builds/reproduce.sh --target "$RUST_TARGET" "$@"

--- a/reproducible_builds/reproduce.sh
+++ b/reproducible_builds/reproduce.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR/cargokit/build_tool"
+
+args=(reproduce-binaries --manifest-dir=../../rust)
+
+if [[ -n "${CARGOKIT_PRECOMPILED_URL_PREFIX:-}" || -n "${CARGOKIT_PRECOMPILED_PUBLIC_KEY:-}" ]]; then
+  if [[ -z "${CARGOKIT_PRECOMPILED_URL_PREFIX:-}" || -z "${CARGOKIT_PRECOMPILED_PUBLIC_KEY:-}" ]]; then
+    echo "CARGOKIT_PRECOMPILED_URL_PREFIX and CARGOKIT_PRECOMPILED_PUBLIC_KEY must be set together." >&2
+    exit 2
+  fi
+  args+=(--url-prefix "$CARGOKIT_PRECOMPILED_URL_PREFIX")
+  args+=(--public-key "$CARGOKIT_PRECOMPILED_PUBLIC_KEY")
+fi
+
+exec dart run build_tool "${args[@]}" "$@"


### PR DESCRIPTION
Companion to SatoshiPortal/bdk-flutter#5 and the reproducible-build bounty in SatoshiPortal/bdk-flutter#1.

This ports the same Cargokit reproducibility verifier to `boltz-dart`, one of the sibling libraries named in the bounty.

What changed:
- Added `build_tool reproduce-binaries`, which rebuilds selected Rust targets locally, downloads the matching `precompiled_<crate-hash>` GitHub release assets, verifies Ed25519 signatures, and byte-compares local vs remote artifacts.
- Added `--url-prefix` and `--public-key` overrides for release verification before committing a `precompiled_binaries` section to `rust/cargokit.yaml`.
- Added bash/Docker wrappers for Linux and Android reproducibility checks.
- Added a macOS wrapper for macOS/iOS targets.
- Documented direct and wrapper usage in `cargokit/docs/precompiled_binaries.md` and `reproducible_builds/README.md`.

Verification performed:
- `dart format lib/src/build_tool.dart lib/src/reproduce_binaries.dart`
- `dart pub get` with Dart 3.4.4
- `dart test` with Dart 3.4.4
- `dart analyze` with Dart 3.4.4 (only existing info: unused private constructor in `options.dart`)
- `dart run build_tool reproduce-binaries --help`
- `dart run build_tool reproduce-binaries --manifest-dir=../../rust --target not-a-target`
- `bash -n reproducible_builds/*.sh`
- `git diff --check`

Payout BTC address for the linked bounty: 39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ
