### PR TITLE
feat: expose batched limits

### DIFF
--- a/ios/Classes/frb_generated.h
+++ b/ios/Classes/frb_generated.h
@@ -145,6 +145,8 @@ typedef struct wire_cst_lnurl {
 typedef struct wire_cst_swap_limits {
   uint64_t minimal;
   uint64_t maximal;
+  uint64_t *maximal_zero_conf;
+  uint64_t *minimal_batched;
 } wire_cst_swap_limits;
 
 typedef struct wire_cst_chain_swap_fees {

--- a/lib/src/generated/api/fees.dart
+++ b/lib/src/generated/api/fees.dart
@@ -253,14 +253,22 @@ class SubmarineFeesAndLimits {
 class SwapLimits {
   final BigInt minimal;
   final BigInt maximal;
+  final BigInt? maximalZeroConf;
+  final BigInt? minimalBatched;
 
   const SwapLimits({
     required this.minimal,
     required this.maximal,
+    this.maximalZeroConf,
+    this.minimalBatched,
   });
 
   @override
-  int get hashCode => minimal.hashCode ^ maximal.hashCode;
+  int get hashCode =>
+      minimal.hashCode ^
+      maximal.hashCode ^
+      maximalZeroConf.hashCode ^
+      minimalBatched.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -268,5 +276,7 @@ class SwapLimits {
       other is SwapLimits &&
           runtimeType == other.runtimeType &&
           minimal == other.minimal &&
-          maximal == other.maximal;
+          maximal == other.maximal &&
+          maximalZeroConf == other.maximalZeroConf &&
+          minimalBatched == other.minimalBatched;
 }

--- a/lib/src/generated/frb_generated.dart
+++ b/lib/src/generated/frb_generated.dart
@@ -3047,11 +3047,13 @@ class BoltzCoreApiImpl extends BoltzCoreApiImplPlatform
   SwapLimits dco_decode_swap_limits(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 4)
+      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return SwapLimits(
       minimal: dco_decode_u_64(arr[0]),
       maximal: dco_decode_u_64(arr[1]),
+      maximalZeroConf: dco_decode_opt_box_autoadd_u_64(arr[2]),
+      minimalBatched: dco_decode_opt_box_autoadd_u_64(arr[3]),
     );
   }
 
@@ -3646,7 +3648,14 @@ class BoltzCoreApiImpl extends BoltzCoreApiImplPlatform
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_minimal = sse_decode_u_64(deserializer);
     var var_maximal = sse_decode_u_64(deserializer);
-    return SwapLimits(minimal: var_minimal, maximal: var_maximal);
+    var var_maximalZeroConf = sse_decode_opt_box_autoadd_u_64(deserializer);
+    var var_minimalBatched = sse_decode_opt_box_autoadd_u_64(deserializer);
+    return SwapLimits(
+      minimal: var_minimal,
+      maximal: var_maximal,
+      maximalZeroConf: var_maximalZeroConf,
+      minimalBatched: var_minimalBatched,
+    );
   }
 
   @protected
@@ -4198,6 +4207,8 @@ class BoltzCoreApiImpl extends BoltzCoreApiImplPlatform
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_64(self.minimal, serializer);
     sse_encode_u_64(self.maximal, serializer);
+    sse_encode_opt_box_autoadd_u_64(self.maximalZeroConf, serializer);
+    sse_encode_opt_box_autoadd_u_64(self.minimalBatched, serializer);
   }
 
   @protected

--- a/lib/src/generated/frb_generated.io.dart
+++ b/lib/src/generated/frb_generated.io.dart
@@ -857,6 +857,10 @@ abstract class BoltzCoreApiImplPlatform extends BaseApiImpl<BoltzCoreWire> {
       SwapLimits apiObj, wire_cst_swap_limits wireObj) {
     wireObj.minimal = cst_encode_u_64(apiObj.minimal);
     wireObj.maximal = cst_encode_u_64(apiObj.maximal);
+    wireObj.maximal_zero_conf =
+        cst_encode_opt_box_autoadd_u_64(apiObj.maximalZeroConf);
+    wireObj.minimal_batched =
+        cst_encode_opt_box_autoadd_u_64(apiObj.minimalBatched);
   }
 
   @protected
@@ -3455,6 +3459,10 @@ final class wire_cst_swap_limits extends ffi.Struct {
 
   @ffi.Uint64()
   external int maximal;
+
+  external ffi.Pointer<ffi.Uint64> maximal_zero_conf;
+
+  external ffi.Pointer<ffi.Uint64> minimal_batched;
 }
 
 final class wire_cst_chain_swap_fees extends ffi.Struct {

--- a/macos/Classes/frb_generated.h
+++ b/macos/Classes/frb_generated.h
@@ -145,6 +145,8 @@ typedef struct wire_cst_lnurl {
 typedef struct wire_cst_swap_limits {
   uint64_t minimal;
   uint64_t maximal;
+  uint64_t *maximal_zero_conf;
+  uint64_t *minimal_batched;
 } wire_cst_swap_limits;
 
 typedef struct wire_cst_chain_swap_fees {

--- a/rust/src/api/fees.rs
+++ b/rust/src/api/fees.rs
@@ -50,6 +50,10 @@ impl Fees {
 pub struct SwapLimits {
     pub minimal: u64,
     pub maximal: u64,
+    /// Submarine pairs only (`GET /swap/submarine`).
+    pub maximal_zero_conf: Option<u64>,
+    /// Submarine pairs only; use for batched swap minimum validation.
+    pub minimal_batched: Option<u64>,
 }
 
 impl From<boltz_client::swaps::boltz::PairLimits> for SwapLimits {
@@ -57,6 +61,8 @@ impl From<boltz_client::swaps::boltz::PairLimits> for SwapLimits {
         SwapLimits {
             minimal: limits.minimal as u64,
             maximal: limits.maximal as u64,
+            maximal_zero_conf: None,
+            minimal_batched: None,
         }
     }
 }
@@ -65,14 +71,18 @@ impl From<boltz_client::swaps::boltz::ReverseLimits> for SwapLimits {
         SwapLimits {
             minimal: limits.minimal as u64,
             maximal: limits.maximal as u64,
+            maximal_zero_conf: None,
+            minimal_batched: None,
         }
     }
 }
 impl From<boltz_client::swaps::boltz::SubmarinePairLimits> for SwapLimits {
     fn from(limits: boltz_client::swaps::boltz::SubmarinePairLimits) -> Self {
         SwapLimits {
-            minimal: limits.minimal as u64,
-            maximal: limits.maximal as u64,
+            minimal: limits.minimal,
+            maximal: limits.maximal,
+            maximal_zero_conf: Some(limits.maximal_zero_conf),
+            minimal_batched: limits.minimal_batched,
         }
     }
 }

--- a/rust/src/api/fees.rs
+++ b/rust/src/api/fees.rs
@@ -50,7 +50,7 @@ impl Fees {
 pub struct SwapLimits {
     pub minimal: u64,
     pub maximal: u64,
-    /// Submarine pairs only (`GET /swap/submarine`).
+    /// Submarine and chain pairs. Maximum amount allowed for zero-conf.
     pub maximal_zero_conf: Option<u64>,
     /// Submarine pairs only; use for batched swap minimum validation.
     pub minimal_batched: Option<u64>,
@@ -61,7 +61,7 @@ impl From<boltz_client::swaps::boltz::PairLimits> for SwapLimits {
         SwapLimits {
             minimal: limits.minimal as u64,
             maximal: limits.maximal as u64,
-            maximal_zero_conf: None,
+            maximal_zero_conf: Some(limits.maximal_zero_conf),
             minimal_batched: None,
         }
     }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -2625,9 +2625,13 @@ impl SseDecode for crate::api::fees::SwapLimits {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_minimal = <u64>::sse_decode(deserializer);
         let mut var_maximal = <u64>::sse_decode(deserializer);
+        let mut var_maximalZeroConf = <Option<u64>>::sse_decode(deserializer);
+        let mut var_minimalBatched = <Option<u64>>::sse_decode(deserializer);
         return crate::api::fees::SwapLimits {
             minimal: var_minimal,
             maximal: var_maximal,
+            maximal_zero_conf: var_maximalZeroConf,
+            minimal_batched: var_minimalBatched,
         };
     }
 }
@@ -3246,6 +3250,8 @@ impl flutter_rust_bridge::IntoDart for crate::api::fees::SwapLimits {
         [
             self.minimal.into_into_dart().into_dart(),
             self.maximal.into_into_dart().into_dart(),
+            self.maximal_zero_conf.into_into_dart().into_dart(),
+            self.minimal_batched.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -3688,6 +3694,8 @@ impl SseEncode for crate::api::fees::SwapLimits {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u64>::sse_encode(self.minimal, serializer);
         <u64>::sse_encode(self.maximal, serializer);
+        <Option<u64>>::sse_encode(self.maximal_zero_conf, serializer);
+        <Option<u64>>::sse_encode(self.minimal_batched, serializer);
     }
 }
 
@@ -4172,6 +4180,8 @@ mod io {
             crate::api::fees::SwapLimits {
                 minimal: self.minimal.cst_decode(),
                 maximal: self.maximal.cst_decode(),
+                maximal_zero_conf: self.maximal_zero_conf.cst_decode(),
+                minimal_batched: self.minimal_batched.cst_decode(),
             }
         }
     }
@@ -4523,6 +4533,8 @@ mod io {
             Self {
                 minimal: Default::default(),
                 maximal: Default::default(),
+                maximal_zero_conf: core::ptr::null_mut(),
+                minimal_batched: core::ptr::null_mut(),
             }
         }
     }
@@ -5711,6 +5723,8 @@ mod io {
     pub struct wire_cst_swap_limits {
         minimal: u64,
         maximal: u64,
+        maximal_zero_conf: *mut u64,
+        minimal_batched: *mut u64,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/test/boltz_standalone_test.dart
+++ b/test/boltz_standalone_test.dart
@@ -56,6 +56,22 @@ void main() {
     expect((chain_fees.btcFees.percentage > 0.0), true);
   });
 
+  test('CHAIN SWAP LIMITS include maximalZeroConf', () async {
+    const boltzUrl = 'https://api.boltz.exchange/v2';
+    final fees = Fees(boltzUrl: boltzUrl);
+    final chain_fees = await fees.chain();
+
+    expect(chain_fees.btcLimits.maximalZeroConf, isNotNull);
+    expect(chain_fees.lbtcLimits.maximalZeroConf, isNotNull);
+
+    print('BTC chain limits: minimal=${chain_fees.btcLimits.minimal}, '
+        'maximal=${chain_fees.btcLimits.maximal}, '
+        'maximalZeroConf=${chain_fees.btcLimits.maximalZeroConf}');
+    print('LBTC chain limits: minimal=${chain_fees.lbtcLimits.minimal}, '
+        'maximal=${chain_fees.lbtcLimits.maximal}, '
+        'maximalZeroConf=${chain_fees.lbtcLimits.maximalZeroConf}');
+  });
+
   test('DECODE EXPIRED BOLT11', () async {
     final decoded = await DecodedInvoice.fromString(s: expiredBolt11Invoice);
     assert(decoded.isExpired);


### PR DESCRIPTION
expose batched limits so that we can use lower minimum amount for boltz sends